### PR TITLE
Add custom metadata entry support

### DIFF
--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -508,7 +508,13 @@ class WorkerMessageHandler {
 
     handler.on(
       "SaveDocument",
-      async function ({ isPureXfa, numPages, annotationStorage, filename }) {
+      async function ({
+        isPureXfa,
+        numPages,
+        annotationStorage,
+        filename,
+        annotationsMetadata,
+      }) {
         const globalPromises = [
           pdfManager.requestLoadedStream(),
           pdfManager.ensureCatalog("acroForm"),
@@ -669,20 +675,45 @@ class WorkerMessageHandler {
         if (xref.trailer) {
           // Get string info from Info in order to compute fileId.
           const infoMap = new Map();
-          const xrefInfo = xref.trailer.get("Info") || null;
-          if (xrefInfo instanceof Dict) {
-            for (const [key, value] of xrefInfo) {
+          let infoRef = xref.trailer.getRaw("Info") || null;
+          let infoDict = xref.trailer.get("Info");
+          if (infoDict instanceof Dict) {
+            for (const [key, value] of infoDict) {
               if (typeof value === "string") {
                 infoMap.set(key, stringToPDFString(value));
               }
             }
+          } else {
+            infoDict = new Dict(xref);
+            if (infoRef === null) {
+              infoRef = xref.getNewTemporaryRef();
+            }
+          }
+
+          if (Array.isArray(annotationsMetadata)) {
+            const arr = [];
+            for (const item of annotationsMetadata) {
+              const d = new Dict(xref);
+              if (item.Guid !== undefined) {
+                d.set("Guid", JSON.stringify(item.Guid));
+              }
+              if (item.DocumentationId !== undefined) {
+                d.set("DocumentationId", item.DocumentationId);
+              }
+              if (item.DocumentationPositionId !== undefined) {
+                d.set("DocumentationPositionId", item.DocumentationPositionId);
+              }
+              arr.push(d);
+            }
+            infoDict.set("VDSPDFAnnotations", arr);
+            changes.put(infoRef, { data: infoDict });
           }
 
           newXrefInfo = {
             rootRef: catalogRef,
             encryptRef: xref.trailer.getRaw("Encrypt") || null,
             newRef: xref.getNewTemporaryRef(),
-            infoRef: xref.trailer.getRaw("Info") || null,
+            infoRef,
             infoMap,
             fileIds: xref.trailer.get("ID") || null,
             startXRef: linearization

--- a/src/display/api.js
+++ b/src/display/api.js
@@ -1011,8 +1011,8 @@ class PDFDocumentProxy {
    * @returns {Promise<Uint8Array>} A promise that is resolved with a
    *   {Uint8Array} containing the full data of the saved document.
    */
-  saveDocument() {
-    return this._transport.saveDocument();
+  saveDocument(annotationsMetadata = null) {
+    return this._transport.saveDocument(annotationsMetadata);
   }
 
   /**
@@ -2796,7 +2796,7 @@ class WorkerTransport {
     return this.messageHandler.sendWithPromise("GetData", null);
   }
 
-  saveDocument() {
+  saveDocument(annotationsMetadata = null) {
     if (this.annotationStorage.size <= 0) {
       warn(
         "saveDocument called while `annotationStorage` is empty, " +
@@ -2813,6 +2813,7 @@ class WorkerTransport {
           numPages: this._numPages,
           annotationStorage: map,
           filename: this._fullReader?.filename ?? null,
+          annotationsMetadata,
         },
         transfer
       )

--- a/test/unit/api_spec.js
+++ b/test/unit/api_spec.js
@@ -28,6 +28,7 @@ import {
   PermissionFlag,
   ResponseException,
   UnknownErrorException,
+  bytesToString,
 } from "../../src/shared/util.js";
 import {
   buildGetDocumentParams,
@@ -131,6 +132,7 @@ describe("api", function () {
 
       await loadingTask.destroy();
     });
+
 
     it("creates pdf doc from URL-object", async function () {
       const urlObj = TestPdfsServer.resolveURL(basicApiFileName);
@@ -3123,6 +3125,25 @@ describe("api", function () {
       expect(field.textContent).toEqual(["Several", "", "Other", "Jobs"]);
 
       await loadingTask.destroy();
+    });
+
+    it("adds VDSPDFAnnotations metadata when saving", async function () {
+      const loadingTask = getDocument(buildGetDocumentParams("empty.pdf"));
+      const pdfDoc = await loadingTask.promise;
+
+      const meta = [
+        {
+          Guid: { x: 123, y: 123, color: "abc123", page: 1 },
+          DocumentationId: 1,
+          DocumentationPositionId: 2,
+        },
+      ];
+
+      const data = await pdfDoc.saveDocument(meta);
+      await loadingTask.destroy();
+
+      expect(bytesToString(new Uint8Array(data)).includes("/VDSPDFAnnotations"))
+        .toEqual(true);
     });
 
     describe("Cross-origin", function () {


### PR DESCRIPTION
## Summary
- support passing extra metadata when saving PDF documents
- store `VDSPDFAnnotations` into the PDF info dictionary
- add unit test verifying metadata write

## Testing
- `npx gulp unittestcli` *(fails: Needs to install gulp)*

------
https://chatgpt.com/codex/tasks/task_e_688a78c6338c832992727ab8afc1e239